### PR TITLE
Never change .sh or gradlew to crlf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sh text eol=lf
+service/gradlew text eol=lf


### PR DESCRIPTION
Tested on windows with 
```
[core]
	autocrlf = true
	eol = crlf
```

and `git clone -b fix_windows_newlines git@github.com:divolte/shop.git`

start.sh and gradlew files were the only ones with lf instead of crlf