### PR TITLE
Enabled test again

### DIFF
--- a/spark-container/streaming/src/test/scala/sparkjob/SparkEventsPerMinuteTest.scala
+++ b/spark-container/streaming/src/test/scala/sparkjob/SparkEventsPerMinuteTest.scala
@@ -15,8 +15,7 @@ class SparkEventsPerMinuteTest
 
   override implicit def reuseContextIfPossible: Boolean = true
 
-  ignore("Testing window function ") {
-    // TODO: fix the test, need to be checked how wondow function with watermarks works
+  test("Testing window function ") {
 
     import spark.implicits._
     val input = Seq(Seq(Input("preview", 1538143025000L)),


### PR DESCRIPTION
When trying to find a fix for issue #24 the test succeeded immediately. Seems the upgrade to spark 2.4 and spark testing 2.4 resolved previous issue. Please check.